### PR TITLE
Fix bugs

### DIFF
--- a/capitulos/capitulo5.tex
+++ b/capitulos/capitulo5.tex
@@ -9,18 +9,20 @@ O Algoritmo \ref{alg:howto} usa o pacote {\texttt algorithm2e} que suporta coman
     \SetAlgoLined
     \Entrada{Entrada do algoritmo}
     \Saida{Saída do Algoritmo}
-    inicialização\;
-    \Enqto{condição}{
-	instrução\;
-	\eSe{condição}{
-	    instrução1\;
-	    instrução2\;
-	}{
-	    instrução3\;
-	}
-    }
-    \Para{i de 1 até 10}{
-	instrução\;
+    \Inicio{
+        inicialização\;
+        \Enqto{condição}{
+    	instrução\;
+    	\eSe{condição}{
+    	    instrução1\;
+    	    instrução2\;
+    	}{
+    	    instrução3\;
+    	}
+        }
+        \Para{i de 1 até 10}{
+    	instrução\;
+        }
     }
     \caption{Como escrever algoritmos}
     \label{alg:howto}

--- a/compile.sh
+++ b/compile.sh
@@ -1,2 +1,3 @@
+bibtex monografia
 pdflatex monografia.tex
 evince monografia.pdf&

--- a/fixos/configuracoes.tex
+++ b/fixos/configuracoes.tex
@@ -8,6 +8,7 @@
 
 
 % Redefinicao de alguns comandos do pacote algorithm2e
+\SetKwBlock{Inicio}{in\'{i}cio}{fim}
 \SetKwFor{Para}{para}{fa\c{c}a}{fim para}%
 \SetKwFor{ParaCada}{para cada}{fa\c{c}a}{fim para}%
 \SetKwIF{Se}{SenaoSe}{Senao}{se}{ent\~{a}o}{sen\~{a}o se}{sen\~{a}o}{fim se}%


### PR DESCRIPTION
Fix bug on portuguese command \Inicio on algorithm2e and add bibtex support compile on compile.sh.

The command \Inicio is shown like:

início
      block commands;
fin
This PR fix that.

The bibtex compile was add, cause when we run it for the first time the references is missing on the document.